### PR TITLE
Bbkane/parse2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,31 @@ below this description) is likely unreleased.
 
 ## Changed
 
-- Moved `SetBy` into the `Value` interface (`value.UpdatedBy()` - this allows `Flag` to be readonly and and makes the coupling between setting the value and updating `UpdatedBy` explicit
+- Moved `SetBy` into the `Value` interface (`value.UpdatedBy()` - this allows
+`Flag` to be readonly and and makes the coupling between setting the value and
+updating `UpdatedBy` explicit
+- Flags must now be the last things passed - i.e. `<appname> <section>
+<command> <flag>...`. In addition, the only flag allowed after a `<section>` is
+the `--help` flag (unfortunately the `--color` flag is NOT currently allowed to
+be passed for section help). This simplifies the parsing and will help with tab
+completion, and after that's implemented I might try to restore the old
+behavior if I get too annoyed with this limitation. Temporarily, the old
+behavior can be restored by setting the `WARG_PRE_V0_0_26_PARSE_ALGORITHM`
+environment variable, but I plan to remove that in the next version.
+
+Examples:
+
+```
+$ go run ./examples/butler --color false -h
+Parse err: Parse args error: expecting section or command, got --color
+exit status 64
+```
+
+```
+$ WARG_PRE_V0_0_26_PARSE_ALGORITHM=1 go run ./examples/butler --color false -h
+A virtual assistant
+# ... more text ...
+```
 
 # v0.0.25
 

--- a/app.go
+++ b/app.go
@@ -322,6 +322,27 @@ func (app *App) Validate() error {
 			return fmt.Errorf("sections must have either child sections or child commands: %#v", secName)
 		}
 
+		{
+			// child section names should not clash with child command names
+			nameCount := make(map[string]int)
+			for name := range flatSec.Sec.Commands {
+				nameCount[string(name)]++
+			}
+			for name := range flatSec.Sec.Sections {
+				nameCount[string(name)]++
+			}
+			errs := []error{}
+			for name, count := range nameCount {
+				if count > 1 {
+					errs = append(errs, fmt.Errorf("command and section name clash: %s", name))
+				}
+			}
+			err := errors.Join(errs...)
+			if err != nil {
+				return fmt.Errorf("name collision: %w", err)
+			}
+		}
+
 		for name, com := range flatSec.Sec.Commands {
 
 			// Commands must not start wtih "-"

--- a/app_help_ext_test.go
+++ b/app_help_ext_test.go
@@ -95,6 +95,17 @@ func TestAppHelp(t *testing.T) {
 		args   []string
 		lookup warg.LookupFunc
 	}{
+		// toplevel just a toplevel help!
+		{
+			name: "toplevel",
+			app: warg.New(
+				"grabbit",
+				grabbitSection(),
+				warg.SkipValidation(),
+			),
+			args:   []string{"grabbit", "--help", "detailed"},
+			lookup: warg.LookupMap(nil),
+		},
 
 		// allcommands (no command help)
 		{

--- a/app_help_ext_test.go
+++ b/app_help_ext_test.go
@@ -103,7 +103,7 @@ func TestAppHelp(t *testing.T) {
 				grabbitSection(),
 				warg.SkipValidation(),
 			),
-			args:   []string{"grabbit", "--help", "detailed"},
+			args:   []string{"grabbit", "-h", "outline"},
 			lookup: warg.LookupMap(nil),
 		},
 

--- a/app_parse.go
+++ b/app_parse.go
@@ -393,9 +393,6 @@ func NewParseOptHolder(opts ...ParseOpt) ParseOptHolder {
 }
 
 func (app *App) parseWithOptHolder(parseOptHolder ParseOptHolder) (*ParseResult, error) {
-
-	return app.parseWithOptHolder2(parseOptHolder)
-
 	osArgs := parseOptHolder.Args
 	osLookupEnv := parseOptHolder.LookupFunc
 
@@ -571,5 +568,6 @@ func (app *App) parseWithOptHolder(parseOptHolder ParseOptHolder) (*ParseResult,
 func (app *App) Parse(opts ...ParseOpt) (*ParseResult, error) {
 
 	parseOptHolder := NewParseOptHolder(opts...)
-	return app.parseWithOptHolder(parseOptHolder)
+	return app.parseWithOptHolder2(parseOptHolder)
+	// return app.parseWithOptHolder(parseOptHolder)
 }

--- a/app_parse.go
+++ b/app_parse.go
@@ -568,6 +568,8 @@ func (app *App) parseWithOptHolder(parseOptHolder ParseOptHolder) (*ParseResult,
 func (app *App) Parse(opts ...ParseOpt) (*ParseResult, error) {
 
 	parseOptHolder := NewParseOptHolder(opts...)
+	if _, exists := os.LookupEnv("WARG_PRE_V0_0_26_PARSE_ALGORITHM"); exists {
+		return app.parseWithOptHolder(parseOptHolder)
+	}
 	return app.parseWithOptHolder2(parseOptHolder)
-	// return app.parseWithOptHolder(parseOptHolder)
 }

--- a/app_parse.go
+++ b/app_parse.go
@@ -391,6 +391,8 @@ func NewParseOptHolder(opts ...ParseOpt) ParseOptHolder {
 
 func (app *App) parseWithOptHolder(parseOptHolder ParseOptHolder) (*ParseResult, error) {
 
+	return app.parseWithOptHolder2(parseOptHolder)
+
 	osArgs := parseOptHolder.Args
 	osLookupEnv := parseOptHolder.LookupFunc
 
@@ -540,7 +542,7 @@ func (app *App) parseWithOptHolder(parseOptHolder ParseOptHolder) (*ParseResult,
 					return &pr, nil
 				}
 			}
-			return nil, fmt.Errorf("some problem with section help: info: %v", helpInfo)
+			return nil, fmt.Errorf("some problem with command help: info: %v", helpInfo)
 		} else {
 
 			pr := ParseResult{

--- a/app_parse.go
+++ b/app_parse.go
@@ -229,7 +229,7 @@ func resolveFlag(
 
 	// update from config
 	{
-		if canUpdate && fl.Value.UpdatedBy() == value.UpdatedByUnset && configReader != nil {
+		if canUpdate && fl.Value.UpdatedBy() == value.UpdatedByUnset && configReader != nil && fl.ConfigPath != "" {
 			fpr, err := configReader.Search(fl.ConfigPath)
 			if err != nil {
 				return err

--- a/app_parse.go
+++ b/app_parse.go
@@ -287,7 +287,10 @@ func resolveFlag(
 	// update from default
 	{
 		if canUpdate && fl.Value.UpdatedBy() == value.UpdatedByUnset && fl.Value.HasDefault() {
-			fl.Value.ReplaceFromDefault(value.UpdatedByDefault)
+			err := fl.Value.ReplaceFromDefault(value.UpdatedByDefault)
+			if err != nil {
+				return fmt.Errorf("error updating flag %v from default: %w", name, err)
+			}
 		}
 	}
 

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -148,12 +148,6 @@ func (a *App) parseArgs(args []string) (ParseResult2, error) {
 			}
 
 		case Parse_ExpectingFlagValue:
-			// don't allow scalar flags to be passed more than once
-			// TODO: Move this inside the scalarValue update check
-			if val, isScalar := pr.FlagValues[pr.CurrentFlagName].(value.ScalarValue); isScalar && val.UpdatedBy() != value.UpdatedByUnset {
-				return pr, fmt.Errorf("scalar flag %s passed more than once", pr.CurrentFlagName)
-			}
-
 			// TODO: unset the flag if UnsetSentinel is passed. Search though global flags and command flags, reset the value to unset sentinal and store in the parseResult that it was unset so calls to resolveFlags won't set it...
 
 			err := pr.FlagValues[pr.CurrentFlagName].Update(arg, value.UpdatedByFlag)
@@ -236,7 +230,10 @@ func resolveFlag2(
 
 	// default
 	if flagValues[flagName].HasDefault() {
-		flagValues[flagName].ReplaceFromDefault(value.UpdatedByDefault)
+		err := flagValues[flagName].ReplaceFromDefault(value.UpdatedByDefault)
+		if err != nil {
+			return fmt.Errorf("error updating flag %v from default: %w", flagName, err)
+		}
 		return nil
 	}
 	return nil

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -109,7 +109,7 @@ func (a *App) parseArgs(args []string) (ParseResult2, error) {
 
 		// --help <helptype> or --help must be the last thing passed and can appear at any state we aren't expecting a flag value
 		if i >= len(args)-2 &&
-			flag.Name(arg) == a.helpFlagName &&
+			(flag.Name(arg) == a.helpFlagName || flag.Name(arg) == a.helpFlagAlias) &&
 			pr.State != Parse_ExpectingFlagValue {
 
 			pr.HelpPassed = true

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -318,7 +318,7 @@ func (a *App) resolveFlags(currentCommand *command.Command, flagValues FlagValue
 func (a *App) Parse2(args []string, lookupEnv LookupFunc) (*ParseResult2, error) {
 	pr, err := a.parseArgs(args)
 	if err != nil {
-		return nil, fmt.Errorf("Parse error: %w", err)
+		return nil, fmt.Errorf("Parse args error: %w", err)
 	}
 
 	// If we're in a section, just print the help
@@ -377,7 +377,7 @@ func (app *App) parseWithOptHolder2(parseOptHolder ParseOptHolder) (*ParseResult
 
 	pr2, err := app.Parse2(parseOptHolder.Args[1:], parseOptHolder.LookupFunc)
 	if err != nil {
-		return nil, fmt.Errorf("parseWithOptHolder2 err: %w", err)
+		return nil, fmt.Errorf("Parse err: %w", err)
 	}
 
 	// build ftar.AvailableFlags - it's a map of string to flag for the app globals + current command. Don't forget to set each flag.IsCommandFlag and Value for now..

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -271,6 +271,11 @@ func (a *App) Parse2(args []string, lookupEnv LookupFunc) (*ParseResult2, error)
 		return nil, fmt.Errorf("Parse error: %w", err)
 	}
 
+	// If we're in a section, just print the help
+	if pr.State == Parse_ExpectingSectionOrCommand {
+		pr.HelpPassed = true
+	}
+
 	// --help means we don't need to do a lot of error checking
 	if pr.HelpPassed {
 		err = a.resolveFlags(pr.CurrentCommand, pr.FlagValues, lookupEnv)

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -268,5 +268,8 @@ func (a *App) resolveFlags(currentCommand *command.Command, flagValues FlagValue
 // - port gzc Parse -> Parse2
 // - make warg.Parse call Parse2 instead of doing the parsing
 // - make all the tests pass (unsetsentinel, etc...)
+// - test against CLI apps
+// - release version
 // - delete old parsing code
-// - update warg.Parse's signature and make tests pass!
+// - update warg.Parse's signature and tests
+// - actually add tab completion (need to stringify values so they can be suggested as flag values)

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -148,6 +148,14 @@ func (a *App) parseArgs(args []string) (ParseResult2, error) {
 			}
 
 		case Parse_ExpectingFlagValue:
+			// don't allow scalar flags to be passed more than once
+			// TODO: Move this inside the scalarValue update check
+			if val, isScalar := pr.FlagValues[pr.CurrentFlagName].(value.ScalarValue); isScalar && val.UpdatedBy() != value.UpdatedByUnset {
+				return pr, fmt.Errorf("scalar flag %s passed more than once", pr.CurrentFlagName)
+			}
+
+			// TODO: unset the flag if UnsetSentinel is passed. Search though global flags and command flags, reset the value to unset sentinal and store in the parseResult that it was unset so calls to resolveFlags won't set it...
+
 			err := pr.FlagValues[pr.CurrentFlagName].Update(arg, value.UpdatedByFlag)
 			if err != nil {
 				return pr, err

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -481,11 +481,3 @@ func (app *App) parseWithOptHolder2(parseOptHolder ParseOptHolder) (*ParseResult
 		return nil, fmt.Errorf("internal Error: invalid parse state: currentSection == %v, currentCommand == %v", pr2.SectionPath, pr2.CurrentCommandName)
 	}
 }
-
-// next steps:
-// - make all the tests pass (unsetsentinel, etc...)
-// - test against CLI apps
-// - release version
-// - delete old parsing code
-// - update warg.Parse's signature and tests
-// - actually add tab completion (need to stringify values so they can be suggested as flag values)

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -57,7 +57,7 @@ const (
 
 func (a *App) parseArgs(args []string) (ParseResult2, error) {
 	pr := ParseResult2{
-		SectionPath:    []string{},
+		SectionPath:    nil,
 		CurrentSection: &a.rootSection,
 
 		CurrentCommandName: "",

--- a/app_parse2.go
+++ b/app_parse2.go
@@ -1,0 +1,155 @@
+package warg
+
+import (
+	"fmt"
+
+	"go.bbkane.com/warg/command"
+	"go.bbkane.com/warg/flag"
+	"go.bbkane.com/warg/section"
+	"go.bbkane.com/warg/value"
+)
+
+// -- FlagValue
+
+type FlagValue struct {
+	SetBy string
+	Value value.Value
+}
+
+type FlagValueMap map[flag.Name]*FlagValue
+
+func (m FlagValueMap) ToPassedFlags() command.PassedFlags {
+	pf := make(command.PassedFlags)
+	for name, f := range m {
+		if f.SetBy != "" {
+			pf[string(name)] = f.Value
+		}
+	}
+	return pf
+}
+
+type ParseResult2 struct {
+	SectionPath    []string
+	CurrentSection *section.SectionT
+
+	CurrentCommandName command.Name
+	CurrentCommand     *command.Command
+
+	CurrentFlagName flag.Name
+	CurrentFlag     *flag.Flag
+
+	FlagValues FlagValueMap
+	State      ParseState
+	HelpPassed bool
+}
+
+type ParseState string
+
+const (
+	Parse_ExpectingSectionOrCommand ParseState = "Parse_ExpectingSectionOrCommand"
+	Parse_ExpectingFlagNameOrEnd    ParseState = "Parse_ExpectingFlagNameOrEnd"
+	Parse_ExpectingFlagValue        ParseState = "Parse_ExpectingFlagValue"
+)
+
+func (a *App) parseArgs(args []string) (ParseResult2, error) {
+	pr := ParseResult2{
+		SectionPath:    []string{},
+		CurrentSection: &a.rootSection,
+
+		CurrentCommandName: "",
+		CurrentCommand:     nil,
+
+		CurrentFlagName: "",
+		CurrentFlag:     nil,
+		FlagValues:      make(FlagValueMap),
+
+		HelpPassed: false,
+
+		State: Parse_ExpectingSectionOrCommand,
+	}
+
+	// fill the FlagValues map with empty values from the app
+	for flagName := range a.globalFlags {
+		val, err := a.globalFlags[flagName].EmptyValueConstructor()
+		// TODO: make this not an error!
+		if err != nil {
+			panic(err)
+		}
+		pr.FlagValues[flagName] = &FlagValue{
+			SetBy: "",
+			Value: val,
+		}
+	}
+
+	for i, arg := range args {
+
+		// --help <helptype> or --help must be the last thing passed and can appear at any state we aren't expecting a flag value
+		if i >= len(args)-2 &&
+			flag.Name(arg) == a.helpFlagName &&
+			pr.State != Parse_ExpectingFlagValue {
+
+			pr.HelpPassed = true
+			// set the value of --help if an arg was passed, otherwise let it resolve with the rest of them...
+			if i == len(args)-2 {
+				err := pr.FlagValues[a.helpFlagName].Value.Update(args[i+1])
+				if err != nil {
+					return pr, fmt.Errorf("error updating help flag: %w", err)
+				}
+				pr.FlagValues[a.helpFlagName].SetBy = "passedarg"
+			}
+
+			return pr, nil
+		}
+
+		switch pr.State {
+		case Parse_ExpectingSectionOrCommand:
+			if childSection, exists := pr.CurrentSection.Sections[section.Name(arg)]; exists {
+				pr.CurrentSection = &childSection
+				pr.SectionPath = append(pr.SectionPath, arg)
+			} else if childCommand, exists := pr.CurrentSection.Commands[command.Name(arg)]; exists {
+				pr.CurrentCommand = &childCommand
+				pr.CurrentCommandName = command.Name(arg)
+
+				for flagName := range pr.CurrentCommand.Flags {
+					_, exists := pr.FlagValues[flagName]
+					if exists {
+						// NOTE: move this check to app construction
+						panic("app flags and command flags cannot share a name: " + flagName)
+					}
+					pr.FlagValues[flagName] = &FlagValue{}
+				}
+
+				pr.State = Parse_ExpectingFlagNameOrEnd
+			} else {
+				return pr, fmt.Errorf("expecting section or command, got %s", arg)
+			}
+
+		case Parse_ExpectingFlagNameOrEnd:
+			// TODO: handle aliases of flags
+			if flagFromArg, exists := a.globalFlags[flag.Name(arg)]; exists {
+				pr.CurrentFlagName = flag.Name(arg)
+				pr.CurrentFlag = &flagFromArg
+				pr.State = Parse_ExpectingFlagValue
+			} else if flagFromArg, exists := pr.CurrentCommand.Flags[flag.Name(arg)]; exists {
+				pr.CurrentFlagName = flag.Name(arg)
+				pr.CurrentFlag = &flagFromArg
+				pr.State = Parse_ExpectingFlagValue
+			} else {
+				// return pr, fmt.Errorf("expecting command flag name %v or app flag name %v, got %s", pr.CurrentCommand.ChildrenNames(), a.GlobalFlags.SortedNames(), arg)
+				return pr, fmt.Errorf("expecting flag name, got %s", arg)
+			}
+
+		case Parse_ExpectingFlagValue:
+			err := pr.FlagValues[pr.CurrentFlagName].Value.Update(arg)
+			if err != nil {
+				return pr, err
+			}
+			pr.FlagValues[pr.CurrentFlagName].SetBy = "passedarg"
+			pr.State = Parse_ExpectingFlagNameOrEnd
+
+		default:
+			panic("unexpected state: " + pr.State)
+		}
+	}
+	return pr, nil
+}

--- a/app_parse_ext_test.go
+++ b/app_parse_ext_test.go
@@ -418,6 +418,32 @@ func TestApp_Parse(t *testing.T) {
 			expectedPassedFlagValues: command.PassedFlags{"--flag": int(1), "--help": "default"},
 			expectedErr:              true,
 		},
+		{
+			name: "passedFlagBeforeCommand",
+			app: warg.New(
+				"newAppName",
+				section.New(
+					"help for test",
+					section.Command(
+						"com",
+						"help for com",
+						command.DoNothing,
+						command.Flag(
+							"--flag",
+							"flag help",
+							scalar.Int(),
+						),
+					),
+				),
+				warg.SkipValidation(),
+			),
+
+			args:                     []string{"app", "--flag", "1", "com"},
+			lookup:                   warg.LookupMap(nil),
+			expectedPassedPath:       []string{"com"},
+			expectedPassedFlagValues: command.PassedFlags{"--flag": int(1), "--help": "default"},
+			expectedErr:              true,
+		},
 	}
 	for _, tt := range tests {
 

--- a/app_parse_ext_test.go
+++ b/app_parse_ext_test.go
@@ -400,6 +400,32 @@ func TestApp_Parse(t *testing.T) {
 			expectedPassedFlagValues: command.PassedFlags{"--flag": map[string]bool{"true": true, "false": false}, "--help": "default"},
 			expectedErr:              false,
 		},
+		{
+			name: "scalarFlagPassedTwice",
+			app: warg.New(
+				"newAppName",
+				section.New(
+					"help for test",
+					section.Command(
+						"com",
+						"help for com1",
+						command.DoNothing,
+						command.Flag(
+							"--flag",
+							"flag help",
+							scalar.Int(),
+						),
+					),
+				),
+				warg.SkipValidation(),
+			),
+
+			args:                     []string{"app", "com", "--flag", "1", "--flag", "2"},
+			lookup:                   warg.LookupMap(nil),
+			expectedPassedPath:       []string{"com"},
+			expectedPassedFlagValues: command.PassedFlags{"--flag": int(1), "--help": "default"},
+			expectedErr:              true,
+		},
 	}
 	for _, tt := range tests {
 

--- a/app_parse_ext_test.go
+++ b/app_parse_ext_test.go
@@ -285,35 +285,6 @@ func TestApp_Parse(t *testing.T) {
 			expectedErr:              true,
 		},
 		{
-			name: "addSectionFlags",
-			app: func() warg.App {
-				fm := flag.FlagMap{
-					"--flag1": flag.New("--flag1 value", scalar.String()),
-					"--flag2": flag.New("--flag1 value", scalar.String()),
-				}
-				app := warg.New(
-					"newAppName",
-					section.New(
-						"help for section",
-						section.Command(
-							"test",
-							"help for test",
-							command.DoNothing,
-							command.ExistingFlags(fm),
-						),
-					),
-					warg.SkipValidation(),
-				)
-				return app
-			}(),
-
-			args:                     []string{t.Name(), "test", "--flag1", "val1"},
-			lookup:                   warg.LookupMap(nil),
-			expectedPassedPath:       []string{"test"},
-			expectedPassedFlagValues: command.PassedFlags{"--flag1": "val1", "--help": "default"},
-			expectedErr:              false,
-		},
-		{
 			name: "addCommandFlags",
 			app: func() warg.App {
 				fm := flag.FlagMap{
@@ -399,6 +370,27 @@ func TestApp_Parse(t *testing.T) {
 			expectedPassedPath:       []string{"com1"},
 			expectedPassedFlagValues: command.PassedFlags{"--flag": map[string]bool{"true": true, "false": false}, "--help": "default"},
 			expectedErr:              false,
+		},
+		{
+			name: "passAbsentSection",
+			app: warg.New(
+				"newAppName",
+				section.New(
+					"help for test",
+					section.Command(
+						"com",
+						"help for com",
+						command.DoNothing,
+					),
+				),
+				warg.SkipValidation(),
+			),
+
+			args:                     []string{"app", "badSectionName"},
+			lookup:                   warg.LookupMap(nil),
+			expectedPassedPath:       []string{"com1"},
+			expectedPassedFlagValues: command.PassedFlags{"--help": "default"},
+			expectedErr:              true,
 		},
 		{
 			name: "scalarFlagPassedTwice",

--- a/app_parse_ext_test.go
+++ b/app_parse_ext_test.go
@@ -487,8 +487,7 @@ func TestApp_Parse_unsetSetinel(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			// A scalar flag can only be passed once - either to set it to something or to ensure it's unset with unsetSentinel. There's no point in allowing it to be passed multiples times since all desired outcomes can be accomplished with a single pass.
-			name: "unsetSentinelScalarError",
+			name: "unsetSentinelScalarUpdate",
 			app: warg.New(
 				"newAppName",
 				section.New(
@@ -507,11 +506,11 @@ func TestApp_Parse_unsetSetinel(t *testing.T) {
 				),
 				warg.SkipValidation(),
 			),
-			args:                     []string{t.Name(), "test", "--flag", "UNSET", "--flag", "justsayno"},
+			args:                     []string{t.Name(), "test", "--flag", "UNSET", "--flag", "setAfter"},
 			lookup:                   warg.LookupMap(nil),
 			expectedPassedPath:       []string{"test"},
-			expectedPassedFlagValues: nil,
-			expectedErr:              true,
+			expectedPassedFlagValues: command.PassedFlags{"--flag": "setAfter", "--help": "default"},
+			expectedErr:              false,
 		},
 		{
 			name: "unsetSentinelSlice",
@@ -553,10 +552,10 @@ func TestApp_Parse_unsetSetinel(t *testing.T) {
 			actualPR, actualErr := tt.app.Parse(warg.OverrideArgs(tt.args), warg.OverrideLookupFunc(tt.lookup))
 
 			if tt.expectedErr {
-				require.NotNil(t, actualErr)
+				require.Error(t, actualErr)
 				return
 			} else {
-				require.Nil(t, actualErr)
+				require.NoError(t, actualErr)
 			}
 			require.Equal(t, tt.expectedPassedPath, actualPR.Context.Path)
 			require.Equal(t, tt.expectedPassedFlagValues, actualPR.Context.Flags)

--- a/app_validate_ext_test.go
+++ b/app_validate_ext_test.go
@@ -100,7 +100,7 @@ func TestApp_Validate(t *testing.T) {
 		},
 
 		{
-			name: "flagNameAliasConflict",
+			name: "commandFlagAliasCommandFlagNameConflict",
 			app: warg.New(
 				"newAppName",
 				section.New("",
@@ -114,7 +114,62 @@ func TestApp_Validate(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "globalFlagNameAliasConflict",
+			name: "commandFlagAliasGlobalFlagAliasConflict",
+			app: warg.New(
+				"newAppName",
+				section.New(
+					"help for test",
+					section.Command(
+						"com",
+						"help for com",
+						command.DoNothing,
+						command.Flag(
+							"--commandflag",
+							"global flag conflict",
+							scalar.String(),
+							flag.Alias("--global"),
+						),
+					),
+				),
+				warg.SkipValidation(),
+				warg.GlobalFlag(
+					"--globalflag",
+					"global flag",
+					scalar.String(),
+					flag.Alias("--global"),
+				),
+			),
+			expectedErr: true,
+		},
+		{
+			name: "commandFlagAliasGlobalFlagNameConflict",
+			app: warg.New(
+				"newAppName",
+				section.New(
+					"help for test",
+					section.Command(
+						"com",
+						"help for com",
+						command.DoNothing,
+						command.Flag(
+							"--commandflag",
+							"global flag conflict",
+							scalar.String(),
+							flag.Alias("--global"),
+						),
+					),
+				),
+				warg.SkipValidation(),
+				warg.GlobalFlag(
+					"--global",
+					"global flag",
+					scalar.String(),
+				),
+			),
+			expectedErr: true,
+		},
+		{
+			name: "commandFlagNameGlobalFlagNameConflict",
 			app: warg.New(
 				"newAppName",
 				section.New(
@@ -145,10 +200,10 @@ func TestApp_Validate(t *testing.T) {
 			actualErr := tt.app.Validate()
 
 			if tt.expectedErr {
-				require.NotNil(t, actualErr)
+				require.Error(t, actualErr)
 				return
 			} else {
-				require.Nil(t, actualErr)
+				require.NoError(t, actualErr)
 			}
 		})
 	}

--- a/app_validate_ext_test.go
+++ b/app_validate_ext_test.go
@@ -194,6 +194,31 @@ func TestApp_Validate(t *testing.T) {
 			),
 			expectedErr: true,
 		},
+		{
+			name: "commandNameSectionNameConflict",
+			app: warg.New(
+				"newAppName",
+				section.New(
+					"help for test",
+					section.Command(
+						"conflict",
+						"help for com",
+						command.DoNothing,
+					),
+					section.Section(
+						"conflict",
+						"help for section",
+					),
+				),
+				warg.SkipValidation(),
+				warg.GlobalFlag(
+					"--global",
+					"global flag",
+					scalar.String(),
+				),
+			),
+			expectedErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/example_config_flag_test.go
+++ b/example_config_flag_test.go
@@ -68,7 +68,7 @@ func ExampleConfigFlag() {
 		log.Fatalf("write error: %e", err)
 	}
 	app.MustRun(
-		warg.OverrideArgs([]string{"calc", "-c", "testdata/ExampleConfigFlag/calc.yaml", "add"}),
+		warg.OverrideArgs([]string{"calc", "add", "-c", "testdata/ExampleConfigFlag/calc.yaml"}),
 	)
 	// Output:
 	// Sum: 6

--- a/example_flag_value_options_test.go
+++ b/example_flag_value_options_test.go
@@ -90,7 +90,7 @@ func ExampleApp_Parse_flag_value_options() {
 		log.Fatalf("write error: %e", err)
 	}
 	app.MustRun(
-		warg.OverrideArgs([]string{"calc", "-c", "testdata/ExampleFlagValueOptions/config.yaml", "show", "--scalar-flag", "b"}),
+		warg.OverrideArgs([]string{"calc", "show", "-c", "testdata/ExampleFlagValueOptions/config.yaml", "--scalar-flag", "b"}),
 	)
 	// Output:
 	// --scalar-flag: "b"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.bbkane.com/warg
 
-go 1.21
+go 1.23
 
 require (
 	github.com/mattn/go-isatty v0.0.20

--- a/testdata/TestAppHelp/toplevel/stdout.golden.txt
+++ b/testdata/TestAppHelp/toplevel/stdout.golden.txt
@@ -1,13 +1,22 @@
-grab those images!
-
-Sections:
-
-  config : Change grabbit's config
-  section2 : another section
-  section3 : another section
-
-Commands:
-
-  command2 : another command
-  command3 : another command
-  grab : do the grabbity grabbity
+# grab those images!
+grabbit
+  # another command
+  command2
+  # another command
+  command3
+  # do the grabbity grabbity
+  grab
+  # Change grabbit's config
+  config
+    # Edit the config. A default config will be created if it doesn't exist
+    edit
+      # path to editor
+      --editor
+  # another section
+  section2
+    # Dummy command to pass validation
+    com
+  # another section
+  section3
+    # Dummy command to pass validation
+    com

--- a/testdata/TestAppHelp/toplevel/stdout.golden.txt
+++ b/testdata/TestAppHelp/toplevel/stdout.golden.txt
@@ -1,0 +1,13 @@
+grab those images!
+
+Sections:
+
+  config : Change grabbit's config
+  section2 : another section
+  section3 : another section
+
+Commands:
+
+  command2 : another command
+  command3 : another command
+  grab : do the grabbity grabbity

--- a/value/dict/dict.go
+++ b/value/dict/dict.go
@@ -147,9 +147,10 @@ func (v *dictValue[_]) UpdatedBy() value.UpdatedBy {
 	return v.updatedBy
 }
 
-func (v *dictValue[_]) ReplaceFromDefault(u value.UpdatedBy) {
+func (v *dictValue[_]) ReplaceFromDefault(u value.UpdatedBy) error {
 	if v.hasDefault {
 		v.vals = v.defaultVals
 		v.updatedBy = u
 	}
+	return nil
 }

--- a/value/scalar/scalar.go
+++ b/value/scalar/scalar.go
@@ -84,7 +84,10 @@ func (v *scalarValue[_]) HasDefault() bool {
 	return v.defaultVal != nil
 }
 
-func (v *scalarValue[_]) ReplaceFromInterface(iFace interface{}, u value.UpdatedBy) error {
+func (v *scalarValue[T]) ReplaceFromInterface(iFace interface{}, u value.UpdatedBy) error {
+	if v.updatedBy != value.UpdatedByUnset {
+		return value.ErrUpdatedMoreThanOnce[T]{CurrentValue: v.val, UpdatedBy: v.updatedBy}
+	}
 	val, err := v.inner.FromIFace(iFace)
 	if err != nil {
 		return err
@@ -112,6 +115,9 @@ func withinChoices[T comparable](val T, choices []T) bool {
 }
 
 func (v *scalarValue[T]) Update(s string, u value.UpdatedBy) error {
+	if v.updatedBy != value.UpdatedByUnset {
+		return value.ErrUpdatedMoreThanOnce[T]{CurrentValue: v.val, UpdatedBy: v.updatedBy}
+	}
 	val, err := v.inner.FromString(s)
 	if err != nil {
 		return err
@@ -128,9 +134,13 @@ func (v *scalarValue[_]) UpdatedBy() value.UpdatedBy {
 	return v.updatedBy
 }
 
-func (v *scalarValue[_]) ReplaceFromDefault(u value.UpdatedBy) {
+func (v *scalarValue[T]) ReplaceFromDefault(u value.UpdatedBy) error {
+	if v.updatedBy != value.UpdatedByUnset {
+		return value.ErrUpdatedMoreThanOnce[T]{CurrentValue: v.val, UpdatedBy: v.updatedBy}
+	}
 	if v.defaultVal != nil {
 		v.updatedBy = u
 		v.val = *v.defaultVal
 	}
+	return nil
 }

--- a/value/slice/slice.go
+++ b/value/slice/slice.go
@@ -144,11 +144,12 @@ func (v *sliceValue[_]) UpdatedBy() value.UpdatedBy {
 	return v.updatedBy
 }
 
-func (v *sliceValue[_]) ReplaceFromDefault(u value.UpdatedBy) {
+func (v *sliceValue[_]) ReplaceFromDefault(u value.UpdatedBy) error {
 	if v.hasDefault {
 		v.vals = v.defaultVals
 		v.updatedBy = u
 	}
+	return nil
 }
 
 func (v *sliceValue[_]) AppendFromInterface(iFace interface{}, u value.UpdatedBy) error {

--- a/value/value.go
+++ b/value/value.go
@@ -45,7 +45,7 @@ type Value interface {
 	UpdatedBy() UpdatedBy
 
 	// ReplaceFromDefault updates the Value from a pre-set default, if one exists. use HasDefault to check whether a default exists
-	ReplaceFromDefault(u UpdatedBy)
+	ReplaceFromDefault(u UpdatedBy) error
 }
 
 type ScalarValue interface {
@@ -95,4 +95,14 @@ type ErrInvalidChoice[T comparable] struct {
 
 func (e ErrInvalidChoice[T]) Error() string {
 	return "invalid choice for value: choices: " + fmt.Sprint(e.Choices)
+}
+
+// ErrUpdatedMoreThanOnce is returned when a value is updated more than once. Only applicable to Scalar Values
+type ErrUpdatedMoreThanOnce[T comparable] struct {
+	CurrentValue T
+	UpdatedBy    UpdatedBy
+}
+
+func (e ErrUpdatedMoreThanOnce[T]) Error() string {
+	return fmt.Sprintf("value already updated to %#v by %s", e.CurrentValue, e.UpdatedBy)
 }

--- a/value/value_ext_test.go
+++ b/value/value_ext_test.go
@@ -10,20 +10,25 @@ import (
 )
 
 func TestIntScalar(t *testing.T) {
-	v := scalar.Int(
+	constructor := scalar.Int(
 		scalar.Choices(1, 2),
 		scalar.Default(2),
-	)()
+	)
 
+	// update, then try to update again
+	v := constructor()
 	err := v.Update("1", value.UpdatedByFlag)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, v.Get().(int), 1)
 
-	err = v.Update("-1", value.UpdatedByFlag)
-	require.NotNil(t, err)
+	// Should only be able to be updated once
+	err = v.Update("1", value.UpdatedByFlag)
+	require.Error(t, err)
 	require.Equal(t, v.Get().(int), 1)
 
-	v.ReplaceFromDefault(value.UpdatedByDefault)
+	v = constructor()
+	err = v.ReplaceFromDefault(value.UpdatedByDefault)
+	require.NoError(t, err)
 	require.Equal(t, v.Get().(int), 2)
 }
 
@@ -61,7 +66,8 @@ func TestIntSlice(t *testing.T) {
 		v.Get().([]int),
 	)
 
-	v.ReplaceFromDefault(value.UpdatedByFlag)
+	err = v.ReplaceFromDefault(value.UpdatedByFlag)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		[]int{1, 1, 1},


### PR DESCRIPTION
# v0.0.26

## Changed

- Moved `SetBy` into the `Value` interface (`value.UpdatedBy()` - this allows
`Flag` to be readonly and and makes the coupling between setting the value and
updating `UpdatedBy` explicit
- Flags must now be the last things passed - i.e. `<appname> <section>
<command> <flag>...`. In addition, the only flag allowed after a `<section>` is
the `--help` flag (unfortunately the `--color` flag is NOT currently allowed to
be passed for section help). This simplifies the parsing and will help with tab
completion, and after that's implemented I might try to restore the old
behavior if I get too annoyed with this limitation. Temporarily, the old
behavior can be restored by setting the `WARG_PRE_V0_0_26_PARSE_ALGORITHM`
environment variable, but I plan to remove that in the next version.

Examples:

```
$ go run ./examples/butler --color false -h
Parse err: Parse args error: expecting section or command, got --color
exit status 64
```

```
$ WARG_PRE_V0_0_26_PARSE_ALGORITHM=1 go run ./examples/butler --color false -h
A virtual assistant
# ... more text ...
```

